### PR TITLE
feat/product - 찜 기능 추가 - 상품목록 및 상품 상세 페이지

### DIFF
--- a/src/api/product.api.ts
+++ b/src/api/product.api.ts
@@ -1,20 +1,20 @@
+import { FavoritedProducts } from '../models/FavoritedProducts.model';
 import { Product } from '../models/product.model';
 import { httpClient } from './http';
 
 /**
  * 전체 상품 조회
  */
-export const fetchProducts = async (page: number = 1) => {
-   const response = await httpClient.get<{ products: Product[]; total: number }>(
-      `/product/products?page=${page},`,
+export const fetchProducts = async () => {
+   const response = await httpClient.get<{ products: Product[]; favoritedProducts: FavoritedProducts[] }>(
+      `/product/products`,
       {
          withCredentials: true,
       },
    );
-   console.log('🔍 fetchProduct 응답:', response.data);
-   return response.data.products.map((product) => ({
-      ...product,
-   }));
+   const products = response.data.products?.map((product) => ({ ...product })) || [];
+   const favoriteProducts = response.data.favoritedProducts?.map((fav) => ({ ...fav })) || [];
+   return { products, favoriteProducts };
 };
 
 /**
@@ -29,23 +29,15 @@ export const fetchProduct = async (id: number) => {
  * 찜하기 추가 (favorite 증가)
  */
 export const addFavorite = async (id: number) => {
-   // const response = await httpClient.post(`/product/favorite/${id}`);
-   // return response.data;
-   return await httpClient.post(
-      `/product/favorite/${id}`,
-      {},
-      {
-         withCredentials: true,
-      },
-   );
+   return await httpClient.post(`/product/favorite/${id}`, {
+      withCredentials: true,
+   });
 };
 
 /**
  * 찜하기 취소 (favorite 감소)
  */
 export const removeFavorite = async (id: number) => {
-   // const response = await httpClient.delete(`/product/favorite/${id}`);
-   // return response.data;
    return await httpClient.delete(`/product/favorite/${id}`, {
       withCredentials: true,
    });

--- a/src/components/products/ProductDetail.tsx
+++ b/src/components/products/ProductDetail.tsx
@@ -1,5 +1,5 @@
 import { ProductDetailStyle } from './ProductDetailStyle';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import Title from '../common/title/Title';
 import { getImgSrc } from '../../utils/image';
 import { Product } from '../../models/product.model';
@@ -31,17 +31,17 @@ const productList = [
 
 export const ProductDetail = () => {
    const { id } = useParams<{ id: string }>();
+   const location = useLocation();
    const { user } = useUser();
    const [product, setProduct] = useState<Product | null>(null);
    const [favorites, setFavorites] = useState(0);
-   const [favorited, setFavorited] = useState(false);
+   const [favorited, setFavorited] = useState<boolean>(location.state?.isFavorited ?? false);
 
    useEffect(() => {
       const loadProduct = async () => {
          const data = await fetchProduct(Number(id));
          setProduct(data ?? null);
          setFavorites(data.favorite_cnt);
-         setFavorited(data.isFavorited ?? false);
       };
 
       loadProduct();
@@ -88,7 +88,6 @@ export const ProductDetail = () => {
                   </dl>
                ))}
 
-               {/* 버튼 추가된 영역 */}
                <div className='product-buttons'>
                   <button
                      className={`favorite-button ${favorited ? 'favorited' : ''}`}

--- a/src/components/products/ProductItem.tsx
+++ b/src/components/products/ProductItem.tsx
@@ -3,17 +3,17 @@ import { Product } from '../../models/product.model';
 import { getImgSrc } from '../../utils/image';
 import { ProductItemStyle } from './ProductItemStyle';
 import { formatNumber } from '../../utils/format';
-import { FaHeart } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 
-interface ProductProps {
+interface ProductItemProps {
    product: Product;
+   isFavorited: boolean;
 }
 
-export const ProductItem = forwardRef<HTMLDivElement, ProductProps>(({ product }, ref) => {
+export const ProductItem = forwardRef<HTMLDivElement, ProductItemProps>(({ product, isFavorited }, ref) => {
    return (
       <ProductItemStyle ref={ref}>
-         <Link to={`/productDetail/${product.id}`} className='product-link'>
+         <Link to={`/productDetail/${product.id}`} state={{ isFavorited }} className='product-link'>
             <div className='img'>
                <img src={getImgSrc()} alt={product.product_nm} />
             </div>
@@ -24,8 +24,8 @@ export const ProductItem = forwardRef<HTMLDivElement, ProductProps>(({ product }
                <p className='seller'>{product.seller_id}</p>
                <div className='bottom-section'>
                   <p className='price'>{formatNumber(product.product_price)}원</p>
-                  <div className='favorite'>
-                     <FaHeart />
+                  <div className={`favorite ${isFavorited ? 'favorited' : ''}`}>
+                     {isFavorited ? '❤️' : '🤍'}
                      <span>{product.favorite_cnt}</span>
                   </div>
                </div>

--- a/src/components/products/ProductList.tsx
+++ b/src/components/products/ProductList.tsx
@@ -4,7 +4,7 @@ import { ProductListStyle } from './ProductListStyle';
 import { useProduct } from '../../hooks/useProducts';
 
 export const ProductList = () => {
-   const { products, loading } = useProduct();
+   const { products, favoriteProducts } = useProduct();
    const [productList, setProductList] = useState(products);
 
    useEffect(() => {
@@ -13,10 +13,10 @@ export const ProductList = () => {
 
    return (
       <ProductListStyle>
-         {productList.map((product) => (
-            <ProductItem key={product.id} product={product} />
-         ))}
-         {loading && <p>Loading...</p>}
+         {productList.map((product) => {
+            const isFavorited = favoriteProducts.some((fav) => fav.product_id === product.id);
+            return <ProductItem key={product.id} product={product} isFavorited={isFavorited} />;
+         })}
       </ProductListStyle>
    );
 };

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,25 +1,25 @@
 import { useEffect, useState } from 'react';
 import { Product } from '../models/product.model';
 import { fetchProducts } from '../api/product.api';
+import { FavoritedProducts } from '../models/FavoritedProducts.model';
 
 export const useProduct = () => {
    const [products, setProducts] = useState<Product[]>([]);
-   const [loading, setLoading] = useState<boolean>(true);
+   const [favoriteProducts, setFavoriteProducts] = useState<FavoritedProducts[]>([]);
 
    useEffect(() => {
       const fetchAllProducts = async () => {
-         setLoading(true);
          try {
-            const allProducts = await fetchProducts();
-            setProducts(allProducts);
+            const { products, favoriteProducts } = await fetchProducts();
+            setProducts(products);
+            setFavoriteProducts(favoriteProducts);
          } catch (error) {
             console.error('상품을 불러오는 중 오류 발생:', error);
          }
-         setLoading(false);
       };
 
       fetchAllProducts();
    }, []);
 
-   return { products, loading };
+   return { products, favoriteProducts };
 };

--- a/src/models/FavoritedProducts.model.ts
+++ b/src/models/FavoritedProducts.model.ts
@@ -1,0 +1,5 @@
+export interface FavoritedProducts {
+   id: number;
+   user_id: number;
+   product_id: number;
+}


### PR DESCRIPTION
### PR 종류

-  [ ] Bugfix
-  [x] New Feature
-  [ ] Documentation
-  [ ] Refactoring
-  [ ] Other

### 핵심 내용

- 메인 페이지 상품 목록에서 개별 아이템의 찜(좋아요) 상태 표시
  - `ProductItem.tsx`에서 `favoriteProducts` 목록을 확인하여 해당 상품이 찜된 상태인지(isFavorited) 판별
  - `isFavorited` 값을 `Link`태그의 `state`로 전달하여 상세 페이지(ProductDetail.tsx)에서도 사용 가능하도록 구현

- 상품 상세 페이지에서 찜(좋아요) 기능 적용

  - `ProductDetail.tsx`(상품 상세보기)에서 `useLocation()`을 사용하여 `ProductItem.tsx`(상품 카드)에서 전달된 `isFavorited` 값을 받아 초기 상태로 설정
  - 찜하기 버튼을 클릭하면 `isFavorited` 상태를 토글, 좋아요 개수(favorite_cnt)를 실시간으로 업데이트
  - `addFavorite`, `removeFavorite` API 호출을 통해 좋아요 상태를 서버에 반영
