### PR TITLE
Feat/product

### DIFF
--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -22,7 +22,7 @@ const Header = () => {
    const handleLogout = async () => {
       await logout();
       setUser(null);
-      navigate('/');
+      window.location.reload();
    };
 
    return (

--- a/src/components/products/ProductItem.tsx
+++ b/src/components/products/ProductItem.tsx
@@ -1,36 +1,78 @@
-import { forwardRef } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { Product } from '../../models/product.model';
 import { getImgSrc } from '../../utils/image';
 import { ProductItemStyle } from './ProductItemStyle';
 import { formatNumber } from '../../utils/format';
 import { Link } from 'react-router-dom';
+import { addFavorite, removeFavorite } from '../../api/product.api';
+import { useUser } from '../../context/UserContext';
 
 interface ProductItemProps {
    product: Product;
    isFavorited: boolean;
+   onFavoriteToggle: (productId: number, isFavorited: boolean) => void; // ✅ 부모 상태 업데이트 함수 추가
 }
 
-export const ProductItem = forwardRef<HTMLDivElement, ProductItemProps>(({ product, isFavorited }, ref) => {
-   return (
-      <ProductItemStyle ref={ref}>
-         <Link to={`/productDetail/${product.id}`} state={{ isFavorited }} className='product-link'>
-            <div className='img'>
-               <img src={getImgSrc()} alt={product.product_nm} />
-            </div>
-            <div className='category-badge'>{product.product_category}</div>
-            <div className='content'>
-               <h2 className='title'>{product.product_nm}</h2>
-               <p className='desc'>{product.product_desc}</p>
-               <p className='seller'>{product.seller_id}</p>
-               <div className='bottom-section'>
-                  <p className='price'>{formatNumber(product.product_price)}원</p>
-                  <div className={`favorite ${isFavorited ? 'favorited' : ''}`}>
-                     {isFavorited ? '❤️' : '🤍'}
-                     <span>{product.favorite_cnt}</span>
+export const ProductItem = forwardRef<HTMLDivElement, ProductItemProps>(
+   ({ product, isFavorited, onFavoriteToggle }, ref) => {
+      const { user } = useUser();
+      const [favorited, setFavorited] = useState<boolean>(isFavorited);
+      const [favorites, setFavorites] = useState<number>(product.favorite_cnt);
+
+      // ✅ 부모(`ProductList.tsx`)에서 `isFavorited` 값이 변경되면 다시 반영
+      useEffect(() => {
+         setFavorited(isFavorited);
+      }, [isFavorited]);
+
+      const handleFavorite = async (event: React.MouseEvent) => {
+         event.preventDefault(); // ✅ 상세 페이지 이동 방지
+         if (!user) {
+            alert('로그인이 필요합니다.');
+            return;
+         }
+
+         try {
+            let updatedFavorited = !favorited;
+            if (updatedFavorited) {
+               await addFavorite(product.id);
+               setFavorites((prev) => prev + 1);
+            } else {
+               await removeFavorite(product.id);
+               setFavorites((prev) => Math.max(prev - 1, 0)); // ✅ 최소값 0 유지
+            }
+
+            setFavorited(updatedFavorited);
+            onFavoriteToggle(product.id, updatedFavorited); // ✅ 부모 상태 업데이트 호출
+         } catch (error) {
+            alert('찜하기 요청 중 오류가 발생했습니다.');
+         }
+      };
+
+      return (
+         <ProductItemStyle ref={ref}>
+            <Link
+               to={`/productDetail/${product.id}`}
+               state={{ isFavorited: favorited }}
+               className='product-link'
+            >
+               <div className='img'>
+                  <img src={getImgSrc()} alt={product.product_nm} />
+               </div>
+               <div className='category-badge'>{product.product_category}</div>
+               <div className='content'>
+                  <h2 className='title'>{product.product_nm}</h2>
+                  <p className='desc'>{product.product_desc}</p>
+                  <p className='seller'>{product.seller_id}</p>
+                  <div className='bottom-section'>
+                     <p className='price'>{formatNumber(product.product_price)}원</p>
+                     <div className={`favorite ${favorited ? 'favorited' : ''}`} onClick={handleFavorite}>
+                        {favorited ? '❤️' : '🤍'}
+                        <span>{favorites}</span>
+                     </div>
                   </div>
                </div>
-            </div>
-         </Link>
-      </ProductItemStyle>
-   );
-});
+            </Link>
+         </ProductItemStyle>
+      );
+   },
+);

--- a/src/components/products/ProductList.tsx
+++ b/src/components/products/ProductList.tsx
@@ -35,7 +35,7 @@ export const ProductList = () => {
                   key={product.id}
                   product={product}
                   isFavorited={isFavorited}
-                  onFavoriteToggle={handleFavoriteToggle} // ✅ 상태 업데이트 함수 전달
+                  onFavoriteToggle={handleFavoriteToggle}
                />
             );
          })}

--- a/src/components/products/ProductList.tsx
+++ b/src/components/products/ProductList.tsx
@@ -3,19 +3,41 @@ import { ProductItem } from './ProductItem';
 import { ProductListStyle } from './ProductListStyle';
 import { useProduct } from '../../hooks/useProducts';
 
+interface FavoritedProduct {
+   product_id: number;
+   user_id?: number;
+}
+
 export const ProductList = () => {
    const { products, favoriteProducts } = useProduct();
    const [productList, setProductList] = useState(products);
+   const [favoriteProductsList, setFavoriteProductsList] = useState<FavoritedProduct[]>(favoriteProducts);
 
    useEffect(() => {
       setProductList(products);
-   }, [products]);
+      setFavoriteProductsList(favoriteProducts);
+   }, [products, favoriteProducts]);
+
+   const handleFavoriteToggle = (productId: number, isFavorited: boolean) => {
+      setFavoriteProductsList((prev) =>
+         isFavorited
+            ? [...prev, { product_id: productId }]
+            : prev.filter((fav) => fav.product_id !== productId),
+      );
+   };
 
    return (
       <ProductListStyle>
          {productList.map((product) => {
-            const isFavorited = favoriteProducts.some((fav) => fav.product_id === product.id);
-            return <ProductItem key={product.id} product={product} isFavorited={isFavorited} />;
+            const isFavorited = favoriteProductsList.some((fav) => fav.product_id === product.id);
+            return (
+               <ProductItem
+                  key={product.id}
+                  product={product}
+                  isFavorited={isFavorited}
+                  onFavoriteToggle={handleFavoriteToggle} // ✅ 상태 업데이트 함수 전달
+               />
+            );
          })}
       </ProductListStyle>
    );


### PR DESCRIPTION
### PR 종류

-  [ ] Bugfix
-  [x] New Feature
-  [ ] Documentation
-  [ ] Refactoring
-  [ ] Other

### 핵심 내용

- 메인 페이지에서 개별 상품 카드에 찜하기 기능을 추가
- `favoriteProducts` 상태를 관리하여 사용자가 찜한 상품을 실시간으로 반영
- `ProductItem`에서 `onFavoriteToggle` 이벤트 핸들러를 추가하여, 찜하기 상태를 업데이트하도록 설정
- 부모(ProductList.tsx)에서 favoriteProducts가 변경될 경우 즉시 반영되도록 useEffect를 활용

### 부가 설명

- `favoriteProducts` 상태 타입을 `{ product_id: number, user_id?: number }[]` 형태로 변경
- `user_id`가 없을 경우에도 타입 오류 없이 관리 가능하도록 수정
- `ProductItem`에서 `preventDefault()`를 사용하여 링크 이동을 막고, onClick 이벤트를 통해 찜하기 동작을 수행하도록 설정
- useState로 개별 `isFavorited` 상태를 관리하며, 부모 컴포넌트(ProductList.tsx)의 상태와 동기화되도록 개선
- 기존 서버 API에서 찜하기 요청(addFavorite, removeFavorite)을 그대로 활용하여 별도의 API 수정 없이 클라이언트에서만 로직을 추가
