### PR TITLE
feat/user 마이페이지 - 회원정보 수정

### DIFF
--- a/src/api/myPage.api.ts
+++ b/src/api/myPage.api.ts
@@ -9,10 +9,10 @@ export const getUserInfo = async (): Promise<User> => {
 };
 
 interface UpdateUserInfoProps {
-   password: string;
+   userId: number;
+   password?: string;
    location: string;
 }
-
 export const updateUserInfo = async (data: UpdateUserInfoProps): Promise<User> => {
    const response = await httpClient.post('/user/updateUserInfo', data, {
       withCredentials: true,

--- a/src/pages/mypage/userInfoTab/UserInfo.tsx
+++ b/src/pages/mypage/userInfoTab/UserInfo.tsx
@@ -11,8 +11,8 @@ interface UserInfoTabProps {
 }
 
 interface PasswordChangeFormProps {
-   password: string;
-   confirmPassword: string;
+   password?: string;
+   confirmPassword?: string;
    location: string;
 }
 
@@ -44,13 +44,13 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({ userData }) => {
          return;
       }
       setIsPasswordEditable((prev) => !prev);
-      reset();
+      reset({ password: '', confirmPassword: '' });
    };
 
    const onSubmit = (data: PasswordChangeFormProps) => {
       const payload = {
-         userId: userData?.id,
-         password: data.password,
+         userId: userData?.id ?? 0,
+         ...(data.password ? { password: data.password } : {}),
          location: data.location,
       };
 
@@ -58,7 +58,6 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({ userData }) => {
          .then(() => {
             showAlert('회원 정보가 성공적으로 변경되었습니다.');
             setIsPasswordEditable(false);
-            reset();
             navigate('/mypage');
          })
          .catch((error: any) => {
@@ -67,6 +66,9 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({ userData }) => {
             showAlert(message);
          });
    };
+
+   const currentLocation = watch('location');
+   const isLocationChanged = userData?.location !== currentLocation;
 
    return (
       <UserInfoStyle>
@@ -103,7 +105,12 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({ userData }) => {
                            },
                         })}
                      />
-                     <button className='pwd-change-btn' type='button' onClick={handleShowPasswordInput}>
+                     <button
+                        className='pwd-change-btn'
+                        type='button'
+                        onClick={handleShowPasswordInput}
+                        disabled={isSocialLogin}
+                     >
                         {isPasswordEditable ? '취소' : '변경'}
                      </button>
                   </div>
@@ -141,7 +148,11 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({ userData }) => {
                   </div>
                </fieldset>
 
-               <button className='save-btn' type='submit' disabled={!isPasswordEditable}>
+               <button
+                  className='save-btn'
+                  type='submit'
+                  disabled={!isLocationChanged && !isPasswordEditable}
+               >
                   저장
                </button>
             </form>


### PR DESCRIPTION
#16 
### PR 종류

-  [ ] Bugfix
-  [x] New Feature
-  [ ] Documentation
-  [ ] Refactoring
-  [ ] Other


### 핵심 내용

- 클라이언트 사이드에서 비밀번호 입력 없이도 거주지역(location)만 수정 가능하도록 수정
- isPasswordEditable 상태와 상관없이 저장 버튼이 활성화되도록 로직 수정
- 비밀번호 변경이 필요하지 않은 경우 `password` 값을 서버에 전달하지 않도록 처리