### PR TITLE
feat/user - 마이페이지(상품관리탭) - 상품 상태 관리 API 요청 통합 처리 및 상품 UI변경

### DIFF
--- a/src/api/myPage.api.ts
+++ b/src/api/myPage.api.ts
@@ -40,13 +40,13 @@ export const getProductsByStatus = async (
 };
 
 /**
- * 📌 상품 상태 업데이트 API 호출 (판매중 / 판매중지)
+ * 상품 상태 업데이트 API 호출 (판매중 / 판매중지 / 삭제)
  * @param productId - 상품 ID
- * @param status - 변경할 상품 상태 ('available' | 'stopped')
+ * @param status - 변경할 상품 상태 ('available' | 'stopped' | 'deleted')
  */
 export const updateProductStatus = async (
    productId: number,
-   status: 'available' | 'stopped',
+   status: 'available' | 'stopped' | 'deleted',
 ): Promise<void> => {
    await httpClient.patch(
       `/product/mypage/product/${productId}/status`,
@@ -55,11 +55,4 @@ export const updateProductStatus = async (
          withCredentials: true,
       },
    );
-};
-
-// 상품 삭제 API 호출
-export const deleteProduct = async (productId: number): Promise<void> => {
-   await httpClient.delete(`/product/mypage/product/${productId}`, {
-      withCredentials: true,
-   });
 };

--- a/src/models/product.model.ts
+++ b/src/models/product.model.ts
@@ -1,21 +1,21 @@
 export interface Product {
-   id: number; // 백엔드에는 ID가 있음
-   product_no: string; // 상품 번호 (백엔드에서 존재)
-   product_nm: string; // 상품 이름
-   product_price: number; // 상품 가격
-   product_category: string; //상품 카테고리
-   product_desc: string; // 상품 상세 설명
-   product_condition: string; // 상품 상태 (new, used, damaged)
-   product_img: string; // 상품 이미지 URL
-   product_reg_date: string; // 상품 등록일
-   expiry_date?: string; // 등록 만료일 (선택적)
-   view_cnt: number; // 조회 수
-   favorite_cnt: number; // 좋아요 수
-   isFavorited?: boolean; // 로그인한 사용자가 찜했는지 여부
-   seller_id: number; // 판매자 ID (User 참조)
-   trade_loc: string; // 거래 희망 장소
-   trade_status: 'available' | 'reserved' | 'completed' | 'stopped'; // 거래 상태 (판매중, 예약중, 판매완료, 판매중지 )
-   trade_complete_date?: string; // 거래 완료 날짜 (선택적)
-   trade_method: string; // 거래 방식 (직거래, 택배 거래 등)
-   buyer_id?: number | null; // 구매자 ID (선택적)
+   id: number;
+   product_no: string;
+   product_nm: string;
+   product_price: number;
+   product_category: string;
+   product_desc: string;
+   product_condition: string;
+   product_img: string;
+   product_reg_date: string;
+   expiry_date?: string;
+   view_cnt: number;
+   favorite_cnt: number;
+   isFavorited?: boolean;
+   seller_id: number;
+   trade_loc: string;
+   trade_status: 'available' | 'reserved' | 'completed' | 'stopped' | 'deleted';
+   trade_complete_date?: string;
+   trade_method: string;
+   buyer_id?: number | null;
 }


### PR DESCRIPTION
### PR 종류

-  [ ] Bugfix
-  [ ] New Feature
-  [ ] Documentation
-  [x] Refactoring
-  [ ] Other

### 핵심 내용

- 상품 관리 페이지에서 판매중지, 판매재개, 삭제 기능을 통합된 상태 변경 API로 처리하도록 리팩토링
- 상품 삭제 시 trade_status를 'deleted'로 변경하고, UI에서 자동으로 목록에서 제외되도록 수정
- 삭제된 상품은 'deleted' 상태로 유지되며, DB에서는 삭제되지 않음

### 부가 설명

- 기존의 삭제 버튼 클릭 시 DELETE 요청을 PATCH 요청으로 변경
- 상태 변경 시 상품 목록을 다시 불러오지 않고, 프론트엔드에서 상태 업데이트를 통해 UI 즉시 반영
- 삭제된 상품은 'deleted' 상태로 변경되며, 목록에서 자동으로 사라지도록 구현
- 상품 관리 탭에서 삭제된 상품을 제외하고 조회되도록 데이터 필터링 추가
